### PR TITLE
Adds generator solution

### DIFF
--- a/src/main/java/dev/morling/demos/simdfizzbuzz/FizzBuzz.java
+++ b/src/main/java/dev/morling/demos/simdfizzbuzz/FizzBuzz.java
@@ -105,6 +105,17 @@ public class FizzBuzz {
         return result;
     }
 
+    public int[] serialFizzBuzzGenerate(int[] values) {
+        int[] result = new int[values.length];
+
+        for (int i = 0; i < result.length; i++) result[i] = i+1;
+        for (int i = 2; i < result.length; i+=3) result[i] = FIZZ;
+        for (int i = 4; i < result.length; i+=5) result[i] = BUZZ;
+        for (int i = 14; i < result.length; i+=15) result[i] = FIZZ_BUZZ;
+
+        return result;
+    }
+
     public int[] simdFizzBuzz(int[] values) {
         int[] result = new int[values.length];
         int i = 0;

--- a/src/main/java/dev/morling/demos/simdfizzbuzz/FizzBuzzBenchmark.java
+++ b/src/main/java/dev/morling/demos/simdfizzbuzz/FizzBuzzBenchmark.java
@@ -59,6 +59,12 @@ public class FizzBuzzBenchmark {
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
+    public void scalarFizzBuzzGenerate(MyState state, Blackhole blackhole) {
+        blackhole.consume(state.fizzBuzz.serialFizzBuzzGenerate(state.values));
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
     public void simdFizzBuzz(MyState state, Blackhole blackhole) {
         blackhole.consume(state.fizzBuzz.simdFizzBuzz(state.values));
     }

--- a/src/test/java/dev/morling/demos/simdfizzbuzz/FizzBuzzTest.java
+++ b/src/test/java/dev/morling/demos/simdfizzbuzz/FizzBuzzTest.java
@@ -52,6 +52,14 @@ public class FizzBuzzTest {
     }
 
     @Test
+    public void serialFizzBuzzGenerate() {
+        var values = IntStream.range(1, 101).toArray();
+        var result = new FizzBuzz().serialFizzBuzzGenerate(values);
+
+        assertThat(result).isEqualTo(FIZZ_BUZZ_1_TO_100);
+    }
+
+    @Test
     public void simdFizzBuzz() {
         var values = IntStream.range(1, 101).toArray();
         var result = new FizzBuzz().simdFizzBuzz(values);


### PR DESCRIPTION
Since input is an ordered list of natural numbers it is possible to
generate the solution.

```
Benchmark                                        (arrayLength)   Mode  Cnt        Score        Error  Units
FizzBuzzBenchmark.scalarFizzBuzz                           256  thrpt    5  1935306.211 ±  26180.141  ops/s
FizzBuzzBenchmark.scalarFizzBuzzGenerate                   256  thrpt    5  4872668.433 ±  28335.600  ops/s
FizzBuzzBenchmark.scalarFizzBuzzMasked                     256  thrpt    5  3588395.492 ±  42181.485  ops/s
FizzBuzzBenchmark.simdFizzBuzz                             256  thrpt    5  5607827.372 ±  90172.612  ops/s
FizzBuzzBenchmark.simdFizzBuzzMasked                       256  thrpt    5  1233374.275 ±  14159.083  ops/s
FizzBuzzBenchmark.simdFizzBuzzMasksInArray                 256  thrpt    5  5548947.105 ± 106726.578  ops/s
FizzBuzzBenchmark.simdFizzBuzzSeparateMaskIndex            256  thrpt    5  7242701.537 ±  47945.910  ops/s
```
Fixes #1

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>